### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,11 +6,11 @@ getRcvBuffer	KEYWORD2
 getRcvByte	KEYWORD2
 getPacketLength	KEYWORD2
 begin	KEYWORD2
-setMode KEYWORD2
+setMode	KEYWORD2
 setChannel	KEYWORD2
 sendPayload	KEYWORD2
 sendAckPayload	KEYWORD2
 receivePayload	KEYWORD2
 flushTxFIFO	KEYWORD2
 flushRxFIFO	KEYWORD2
-RFM KEYWORD1
+RFM	KEYWORD1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords